### PR TITLE
Try next favorite device if SetAsDefault failed

### DIFF
--- a/FortyOne.AudioSwitcher/AudioSwitcher.cs
+++ b/FortyOne.AudioSwitcher/AudioSwitcher.cs
@@ -413,12 +413,20 @@ namespace FortyOne.AudioSwitcher
             {
                 if (FavouriteDeviceManager.FavouriteDeviceCount > 0)
                 {
-                    var devid = FavouriteDeviceManager.GetNextFavouritePlaybackDevice();
+                    var changed = false;
+                    var currentDefaultDevice = AudioDeviceManager.Controller.DefaultPlaybackDevice;
+                    var candidate = FavouriteDeviceManager.GetNextFavouritePlaybackDevice(currentDefaultDevice);
+                    var attemptsCount = FavouriteDeviceManager.FavouritePlaybackDeviceCount;
+                    for (var i = 0; !changed && i < attemptsCount; i++)
+                    {
+                        changed = candidate.SetAsDefault();
 
-                    AudioDeviceManager.Controller.GetDevice(devid).SetAsDefault();
+                        if (changed && Program.Settings.DualSwitchMode)
+                            candidate.SetAsDefaultCommunications();
 
-                    if (Program.Settings.DualSwitchMode)
-                        AudioDeviceManager.Controller.GetDevice(devid).SetAsDefaultCommunications();
+                        if (!changed)
+                            candidate = FavouriteDeviceManager.GetNextFavouritePlaybackDevice(candidate);
+                    }
                 }
             }
             else

--- a/FortyOne.AudioSwitcher/FavouriteDeviceManager.cs
+++ b/FortyOne.AudioSwitcher/FavouriteDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using AudioSwitcher.AudioApi;
 
 namespace FortyOne.AudioSwitcher
@@ -19,6 +20,14 @@ namespace FortyOne.AudioSwitcher
         public static int FavouriteDeviceCount
         {
             get { return FavouriteDeviceIDs.Count; }
+        }
+
+        public static int FavouritePlaybackDeviceCount
+        {
+            get
+            {
+                return FavouriteDeviceIDs.Count(id => AudioDeviceManager.Controller.GetDevice(id).IsPlaybackDevice);
+            }
         }
 
         public static ReadOnlyCollection<Guid> FavouriteDevices
@@ -84,15 +93,20 @@ namespace FortyOne.AudioSwitcher
                 FavouriteDevicesChanged(FavouriteDeviceIDs);
         }
 
-        public static Guid GetNextFavouritePlaybackDevice()
+        public static IDevice GetNextFavouritePlaybackDevice(IDevice device)
         {
-            var device = AudioDeviceManager.Controller.DefaultPlaybackDevice;
+            var nextDeviceId = GetNextFavouritePlaybackDeviceId(device != null ? device.Id : Guid.Empty);
+            return AudioDeviceManager.Controller.GetDevice(nextDeviceId);
+        }
+
+        public static Guid GetNextFavouritePlaybackDeviceId(Guid deviceId)
+        {
             var index = 0;
 
-            if (device != null)
+            if (deviceId != Guid.Empty)
             {
                 //Start at the next device
-                index = (FavouriteDeviceIDs.IndexOf(device.Id) + 1) % FavouriteDeviceIDs.Count;
+                index = (FavouriteDeviceIDs.IndexOf(deviceId) + 1) % FavouriteDeviceIDs.Count;
             }
 
             var i = index;

--- a/FortyOne.AudioSwitcher/FavouriteDeviceManager.cs
+++ b/FortyOne.AudioSwitcher/FavouriteDeviceManager.cs
@@ -26,7 +26,11 @@ namespace FortyOne.AudioSwitcher
         {
             get
             {
-                return FavouriteDeviceIDs.Count(id => AudioDeviceManager.Controller.GetDevice(id).IsPlaybackDevice);
+                return FavouriteDeviceIDs.Count(id =>
+                {
+                    var device = AudioDeviceManager.Controller.GetDevice(id);
+                    return device != null && device.IsPlaybackDevice;
+                });
             }
         }
 


### PR DESCRIPTION
Quick switch didn't work if the next favorite device can't be set as
default (SetAsDefault method returns false for some reason). So I
implemented attempts to set other favorite devices as default. I limited
attempts count to playback favorites count.