### PR TITLE
Avoid unnecessary config file writing on window close

### DIFF
--- a/FortyOne.AudioSwitcher/AudioSwitcher.cs
+++ b/FortyOne.AudioSwitcher/AudioSwitcher.cs
@@ -1278,8 +1278,6 @@ namespace FortyOne.AudioSwitcher
                     Hide();
                     MinimizeFootprint();
                 }
-
-                HotKeyManager.SaveHotKeys();
             }
         }
 


### PR DESCRIPTION
I have the "Close to Tray" setting checked, and I noticed the config file is written every time I close to tray the program window. (disclaimer: I have a SSD disk and a bit of OCPD)

So, I traced the culprit back to the line here. It was added in https://github.com/xenolightning/AudioSwitcher_v1/commit/dc73f0cfec11540d537c7f413dac7b5429479efd. It seems to be unnecessary because the config file is already written when a hotkey is added or deleted (see [`HotKeyManager`](https://github.com/xenolightning/AudioSwitcher_v1/blob/master/FortyOne.AudioSwitcher/HotKeyData/HotKeyManager.cs) and the "magic" setters in e.g. [`JsonSettings`](https://github.com/xenolightning/AudioSwitcher_v1/blob/master/FortyOne.AudioSwitcher/Configuration/JsonSettings.cs)). Note that at the time the line was added, the configuration wasn't yet using the [new system](https://github.com/xenolightning/AudioSwitcher_v1/commit/f6c6f0e42f06da844ef579d045feb7aa3dd07da1).