### PR TITLE
Hot Key Form - Device List wasn't taking user preference into consideration

### DIFF
--- a/FortyOne.AudioSwitcher/HotKeyForm.cs
+++ b/FortyOne.AudioSwitcher/HotKeyForm.cs
@@ -16,6 +16,8 @@ namespace FortyOne.AudioSwitcher
         private readonly HotKey _hotkey;
         private readonly HotKey _linkedHotKey;
         private readonly HotKeyFormMode _mode = HotKeyFormMode.Normal;
+        private DeviceState _deviceStateFilter = DeviceState.Active;
+
         private bool _firstFocus = true;
 
         public HotKeyForm()
@@ -24,11 +26,18 @@ namespace FortyOne.AudioSwitcher
 
             _hotkey = new HotKey();
 
+            // Keep in mind how the user wants the devices shown
+            if (Program.Settings.ShowDisabledDevices)
+                _deviceStateFilter |= DeviceState.Disabled;
+
+            if (Program.Settings.ShowDisconnectedDevices)
+                _deviceStateFilter |= DeviceState.Unplugged;
+
             cmbDevices.Items.Clear();
-            foreach (var ad in AudioDeviceManager.Controller.GetPlaybackDevices())
+            foreach (var ad in AudioDeviceManager.Controller.GetPlaybackDevices(_deviceStateFilter))
                 cmbDevices.Items.Add(ad);
 
-            foreach (var ad in AudioDeviceManager.Controller.GetCaptureDevices())
+            foreach (var ad in AudioDeviceManager.Controller.GetCaptureDevices(_deviceStateFilter))
                 cmbDevices.Items.Add(ad);
 
             cmbDevices.DisplayMember = "FullName";


### PR DESCRIPTION
On the Hot Key form, the list of devices was not filtering out any of the devices, based on user preference.

It should now only show active playback devices or capture devices, and depending on user preference, the disabled and or the disconnected devices.

This follows how the devices are being handled on the Playback and Recording pages