### PR TITLE
Adding a checkbox for controlling if the window opens on double click

### DIFF
--- a/FortyOne.AudioSwitcher/AudioSwitcher.Designer.cs
+++ b/FortyOne.AudioSwitcher/AudioSwitcher.Designer.cs
@@ -72,6 +72,7 @@
 			this.chkAutoStartWithWindows = new System.Windows.Forms.CheckBox();
 			this.chkStartMinimized = new System.Windows.Forms.CheckBox();
 			this.chkDisableHotKeys = new System.Windows.Forms.CheckBox();
+			this.chkDisableDblClick = new System.Windows.Forms.CheckBox();
 			this.chkQuickSwitch = new System.Windows.Forms.CheckBox();
 			this.tapHotkeys = new System.Windows.Forms.TabPage();
 			this.btnClearAll = new System.Windows.Forms.Button();
@@ -418,6 +419,7 @@
 			this.tapSettings.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
 			this.tapSettings.Size = new System.Drawing.Size(264, 312);
 			this.tapSettings.TabIndex = 3;
+			this.tapSettings.Controls.Add(this.chkDisableDblClick);
 			this.tapSettings.Text = "Settings";
 			this.tapSettings.UseVisualStyleBackColor = true;
 			// 
@@ -456,6 +458,18 @@
 			this.chkShowDPDeviceIconInTray.Text = "Show Default Playback Device icon in tray";
 			this.chkShowDPDeviceIconInTray.UseVisualStyleBackColor = true;
 			this.chkShowDPDeviceIconInTray.CheckedChanged += new System.EventHandler(this.chkShowDPDeviceIconInTray_CheckedChanged);
+			//
+			// chkDisableDblClick
+			// 
+			this.chkDisableDblClick.AutoSize = true;
+			this.chkDisableDblClick.Location = new System.Drawing.Point(14, 269);
+			this.chkDisableDblClick.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.chkDisableDblClick.Name = "chkDisableDblClick";
+			this.chkDisableDblClick.Size = new System.Drawing.Size(352, 29);
+			this.chkDisableDblClick.TabIndex = 8;
+			this.chkDisableDblClick.Text = "Disable double click to open settings";
+			this.chkDisableDblClick.UseVisualStyleBackColor = true;
+			this.chkDisableDblClick.CheckedChanged += new System.EventHandler(this.chkDisableDblClick_CheckedChanged);
 			// 
 			// btnCheckUpdate
 			// 
@@ -1131,6 +1145,7 @@
         private System.Windows.Forms.PictureBox openControlPanelPlayback;
         private System.Windows.Forms.PictureBox openControlPanelRecording;
 		private System.Windows.Forms.CheckBox chkShowUnknownDevicesInHotkeyList;
+		private System.Windows.Forms.CheckBox chkDisableDblClick;
 	}
 }
 

--- a/FortyOne.AudioSwitcher/AudioSwitcher.cs
+++ b/FortyOne.AudioSwitcher/AudioSwitcher.cs
@@ -765,6 +765,7 @@ namespace FortyOne.AudioSwitcher
             chkAutoStartWithWindows.Checked = Program.Settings.AutoStartWithWindows;
             chkDisableHotKeys.Checked = Program.Settings.DisableHotKeys;
             chkQuickSwitch.Checked = Program.Settings.EnableQuickSwitch;
+            chkDisableDblClick.Checked = Program.Settings.DisableDoubleClick;
             chkDualSwitchMode.Checked = Program.Settings.DualSwitchMode;
             chkNotifyUpdates.Checked = Program.Settings.UpdateNotificationsEnabled;
 
@@ -1317,9 +1318,12 @@ namespace FortyOne.AudioSwitcher
 
         private void notifyIcon1_DoubleClick(object sender, EventArgs e)
         {
-            Show();
-            BringToFront();
-            SetForegroundWindow(Handle);
+            if (!Program.Settings.DisableDoubleClick)
+            {
+                Show();
+                BringToFront();
+                SetForegroundWindow(Handle);
+            }
         }
 
         private void Form1_Activated(object sender, EventArgs e)
@@ -1363,6 +1367,10 @@ namespace FortyOne.AudioSwitcher
         private void chkQuickSwitch_CheckedChanged(object sender, EventArgs e)
         {
             Program.Settings.EnableQuickSwitch = chkQuickSwitch.Checked;
+        }
+        private void chkDisableDblClick_CheckedChanged(object sender, EventArgs e)
+        {
+            Program.Settings.DisableDoubleClick = chkDisableDblClick.Checked;
         }
 
         private void chkDualSwitchMode_CheckedChanged(object sender, EventArgs e)

--- a/FortyOne.AudioSwitcher/Configuration/ConfigurationSettings.cs
+++ b/FortyOne.AudioSwitcher/Configuration/ConfigurationSettings.cs
@@ -17,6 +17,7 @@ namespace FortyOne.AudioSwitcher.Configuration
         public const string SETTING_WINDOWHEIGHT = "WindowHeight";
         public const string SETTING_DISABLEHOTKEYS = "DisableHotKeys";
         public const string SETTING_ENABLEQUICKSWITCH = "EnableQuickSwitch";
+        public const string SETTING_DISABLEDOUBLECLICK = "DisableDoubleClick";
         public const string SETTING_CHECKFORUPDATESONSTARTUP = "CheckForUpdatesOnStartup";
         public const string SETTING_POLLFORUPDATES = "PollForUpdates";
         public const string SETTING_STARTUPRECORDINGDEVICE = "StartupRecordingDeviceID";
@@ -230,6 +231,16 @@ namespace FortyOne.AudioSwitcher.Configuration
             set { _configWriter.Set(SETTING_ENABLEQUICKSWITCH, value.ToString()); }
         }
 
+        public bool DisableDoubleClick
+        {
+            get
+            {
+                return
+                    Convert.ToBoolean(_configWriter.Get(SETTING_DISABLEDOUBLECLICK));
+            }
+            set { _configWriter.Set(SETTING_DISABLEDOUBLECLICK, value.ToString()); }
+        }
+
         public bool UpdateNotificationsEnabled
         {
             get
@@ -256,6 +267,9 @@ namespace FortyOne.AudioSwitcher.Configuration
 
             if (!SettingExists(SETTING_ENABLEQUICKSWITCH))
                 EnableQuickSwitch = false;
+
+            if (!SettingExists(SETTING_DISABLEDOUBLECLICK))
+                DisableDoubleClick = false;
 
             if (!SettingExists(SETTING_HOTKEYS))
                 HotKeys = "[]";
@@ -310,6 +324,7 @@ namespace FortyOne.AudioSwitcher.Configuration
             DisableHotKeys = otherSettings.DisableHotKeys;
             DualSwitchMode = otherSettings.DualSwitchMode;
             EnableQuickSwitch = otherSettings.EnableQuickSwitch;
+            DisableDoubleClick = otherSettings.DisableDoubleClick;
             FavouriteDevices = otherSettings.FavouriteDevices;
             HotKeys = otherSettings.HotKeys;
             PollForUpdates = otherSettings.PollForUpdates;


### PR DESCRIPTION
My pain point was that instead of a quick switch of the audio devices, a double click on the tray icon frequently opened the application window instead. So I added a checkbox controlling this behavior in the settings tab.